### PR TITLE
Private API fixed

### DIFF
--- a/crypto_com/crypto_com.py
+++ b/crypto_com/crypto_com.py
@@ -99,14 +99,15 @@ class AuthenticatedClient(CryptoClient):
     async def authenticate(self):
         """Perform authentication"""
         logger.info("Authenticating...")
-        await self.send(self.build_message(
+        message = self.build_message(
             method="public/auth",
             api_key=self.api_key
-        ))
-
-    async def send(self, message):
-        """Serialize and send the message"""
-        await self.websocket.send(dumps(self.sign_message(message)))
+        )
+        signed_message = dumps(self.sign_message(message))
+        await self.websocket.send(signed_message)
+        auth_event = await self.next_event()
+        if auth_event["code"] != 0:
+            raise Exception(f"Authentication failed with code {auth_event['code']}: {auth_event['message']}. Please check your API KEY and SECRET KEY")
 
 
 class MarketClient(CryptoClient):

--- a/examples/get_order_history.py
+++ b/examples/get_order_history.py
@@ -1,0 +1,32 @@
+from crypto_com import UserClient
+import asyncio
+import os
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+async def run():
+    async with UserClient(
+            api_key=os.environ["API_KEY"],
+            api_secret=os.environ["API_SECRET"]
+    ) as client:
+        await client.authenticate()
+        await client.send(
+            client.build_message(
+                method="private/get-order-history",
+                params={
+                    "instrument_name": "CRO_USDC",
+                    "start_ts": 1587846300000,
+                    "end_ts": 1587846358253,
+                    "page_size": 0,
+                    "page": 0
+                }
+            )
+        )
+        event = await client.next_event()
+        print(event)
+
+
+if __name__ == "__main__":
+    loop = asyncio.get_event_loop()
+    loop.run_until_complete(run())

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,23 +1,23 @@
 [[package]]
 name = "orjson"
-version = "3.8.2"
+version = "3.9.13"
 description = "Fast, correct Python JSON library supporting dataclasses, datetimes, and numpy"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [[package]]
 name = "websockets"
-version = "10.4"
+version = "12.0"
 description = "An implementation of the WebSocket Protocol (RFC 6455 & 7692)"
 category = "main"
 optional = false
-python-versions = ">=3.7"
+python-versions = ">=3.8"
 
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8"
-content-hash = "37accde874b1f8e74221ecfbc5355e142fcf53377ee2f4f179b595df798c8235"
+content-hash = "9cd3949f61bed4d942cf7b45725ca6d00a521a4227a9d79a92778e8fce5afba9"
 
 [metadata.files]
 orjson = []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "crypto-com-client"
-version = "1.1"
+version = "1.2"
 description = "Crypto.com websocket api client"
 authors = ["Alvaro Garcia <maxpowel@gmail.com>"]
 license = "Apache-2.0"
@@ -16,7 +16,7 @@ packages = [
 
 [tool.poetry.dependencies]
 python = ">=3.8"
-websockets = "^10"
+websockets = "^12"
 orjson = "^3"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
Now the exchange does not need signed messages once auth is successful. Only the authenticate payload has to be signed, other messages does not.
